### PR TITLE
feat: Add GitHub Actions workflow for building Docker images

### DIFF
--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
 
+name: Test build docker
 jobs:
   build-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-docker.yml
+++ b/.github/workflows/test-build-docker.yml
@@ -1,0 +1,32 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dockerfile: [Dockerfile, Dockerfile.gpu]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image with caching
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          tags: quivrhq/megaparse:${{ matrix.dockerfile }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow file, "test-build-docker.yml", which is responsible for building Docker images. The workflow is triggered on pull requests to the main branch. It uses the "ubuntu-latest" runner and supports building both regular and GPU-enabled Docker images by utilizing the "Dockerfile" and "Dockerfile.gpu" files respectively. The workflow also sets up QEMU and Docker Buildx for the build process. The resulting Docker images are not pushed to a registry but are cached for future builds.

Refs: #187