### PR TITLE
fix: hatchling version

### DIFF
--- a/libs/megaparse/pyproject.toml
+++ b/libs/megaparse/pyproject.toml
@@ -49,7 +49,7 @@ api = [
 
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [tool.rye]

--- a/libs/megaparse_sdk/pyproject.toml
+++ b/libs/megaparse_sdk/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 requires-python = "< 3.12"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [tool.rye]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [tool.rye]


### PR DESCRIPTION
Fix version to force pypi Metadata Version 2.3 (2.4 is not yet supported)