### PR TITLE
fix(megaparse): logging error typecasting to string

### DIFF
--- a/libs/megaparse/src/megaparse/utils/onnx.py
+++ b/libs/megaparse/src/megaparse/utils/onnx.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("megaparse")
 
 def get_providers(device: DeviceEnum) -> List[str]:
     prov = rt.get_available_providers()
-    logger.info("Available providers:", prov)
+    logger.info("Available providers: %s", prov)
     if device == DeviceEnum.CUDA:
         if "CUDAExecutionProvider" not in prov:
             raise ValueError(


### PR DESCRIPTION
```
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\logging\__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\logging\__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\logging\__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\logging\__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Scripts\uvicorn.exe\__main__.py", line 7, in <module>
    sys.exit(main())
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\click\core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\click\core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\click\core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\click\core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\uvicorn\main.py", line 412, in main
    run(
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\uvicorn\main.py", line 579, in run
    server.run()
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\uvicorn\server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\runners.py", line 190, in run
    return runner.run(main)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\base_events.py", line 641, in run_until_complete
    self.run_forever()
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\windows_events.py", line 321, in run_forever
    super().run_forever()
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\base_events.py", line 608, in run_forever
    self._run_once()
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\base_events.py", line 1936, in _run_once
    handle._run()
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\asyncio\events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\uvicorn\protocols\http\h11_impl.py", line 403, in run_asgi   
    result = await app(  # type: ignore[func-returns-value]
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\uvicorn\middleware\proxy_headers.py", line 60, in __call__   
    return await self.app(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\fastapi\applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\middleware\errors.py", line 165, in __call__       
    await self.app(scope, receive, _send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\middleware\cors.py", line 93, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\middleware\cors.py", line 144, in simple_response  
    await self.app(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\middleware\exceptions.py", line 62, in __call__    
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\_exception_handler.py", line 42, in wrapped_app    
    await app(scope, receive, sender)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\_exception_handler.py", line 42, in wrapped_app    
    await app(scope, receive, sender)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\starlette\routing.py", line 73, in app
    response = await f(request)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\fastapi\routing.py", line 301, in app
    raw_response = await run_endpoint_function(
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\fastapi\routing.py", line 212, in run_endpoint_function      
    return await dependant.call(**values)
  File "C:\Users\Lenovo\OneDrive\Desktop\Personal\AKGNI\Odin Audio\ingka-odin-platform-backend\services\odin-audio\src\routes\audio.py", line 111, in upload_pdf
    text = extract_text_from_pdf(temp_path)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\openinference\instrumentation\config.py", line 780, in sync_wrapper
    output = wrapped(*args, **kwargs)
  File "C:\Users\Lenovo\OneDrive\Desktop\Personal\AKGNI\Odin Audio\ingka-odin-platform-backend\services\odin-audio\src\core\utils.py", line 143, in extract_text_from_pdf
    text = MegaParse().load(file_path)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\megaparse\megaparse.py", line 45, in __init__
    self.layout_model = LayoutDetector()
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\megaparse\layout_detection\layout_detector.py", line 57, in __init__
    providers = get_providers(self.device)
  File "C:\Users\Lenovo\.conda\envs\odin-audio\Lib\site-packages\megaparse\utils\onnx.py", line 13, in get_providers
    logger.info("Available providers:", prov)
Message: 'Available providers:'
Arguments: (['AzureExecutionProvider', 'CPUExecutionProvider'],)
```
