### PR TITLE
fix: fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11.10-slim-bullseye
 WORKDIR /app
 
 # Install runtime dependencies
-RUN apt-get update && apt-get upgrade && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libgeos-dev \
     libcurl4-openssl-dev \
     libssl-dev \
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
     build-essential \
     libtool \
     python-dev \
-    build-essential \
     wget \
     gcc \
     # Additional dependencies for document handling
@@ -35,7 +34,7 @@ RUN pip install uv
 RUN uv pip install --no-cache --system -r requirements.lock
 
 RUN playwright install --with-deps
-RUN python3 - -m nltk.downloader all
+RUN python3 -m nltk.downloader all
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- add '-y' to line 6
- remove build-essential from line 18(duplicated)
- remove '-' from line 38

## Description
- Added the -y option to line 6 to resolve the "failed to solve" error that occurs during docker image build
- Removed duplicate 'build-essential' command in line 18
- Removed the incorrect hyphen in line 38 of the dockerfile that was preventing nltk.download from proceeding normally, which caused a 403 Forbidden error when parsing files with extensions other than xlsx, csv, and pdf
